### PR TITLE
fix: fix moveTableauToFoundation test

### DIFF
--- a/test/domain/game_service_test.dart
+++ b/test/domain/game_service_test.dart
@@ -135,9 +135,9 @@ void main() {
       expect(service.moveWasteToFoundation, isA<Function>());
     });
 
-    test('moveTableauToFoundation returns null for invalid move', () {
+    test('moveTableauToFoundation returns null for invalid foundation index', () {
       final service = GameService.newGame();
-      final result = service.moveTableauToFoundation(0, 0);
+      final result = service.moveTableauToFoundation(0, 5); // Invalid foundation index
 
       expect(result, isNull);
     });


### PR DESCRIPTION
Closes #15

## Summary
- Fixed test `moveTableauToFoundation returns null for invalid move` to properly test with an invalid foundation index

## Test Plan
- All 224 tests pass
- Coverage at 92.1% (above 90% threshold)