### PR TITLE
feat: Implement Scoring & Game Options UI (Phase 7)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:solitaire/src/domain/game_state.dart';
+import 'package:solitaire/src/domain/game_service.dart';
 import 'package:solitaire/src/domain/playing_card.dart';
+import 'package:solitaire/src/hint_service.dart';
+import 'package:solitaire/src/screens/settings_screen.dart';
 import 'package:solitaire/src/widgets/board_widget.dart';
+import 'package:solitaire/src/widgets/control_buttons_widget.dart';
+import 'package:solitaire/src/widgets/score_display_widget.dart';
 
 void main() {
   runApp(const SolitaireApp());
@@ -31,68 +37,140 @@ class SolitaireHome extends StatefulWidget {
 }
 
 class _SolitaireHomeState extends State<SolitaireHome> {
-  late GameState _gameState;
+  late GameService _gameService;
+  Timer? _timer;
+  Hint? _currentHint;
 
   @override
   void initState() {
     super.initState();
-    _gameState = GameState.initial();
+    _startNewGame();
+    _startTimer();
   }
 
-  void _drawFromStock() {
-    setState(() {
-      _gameState = _gameState.drawFromStock();
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      setState(() {});
     });
+  }
+
+  void _startNewGame() {
+    _gameService = GameService.newGame();
+    _currentHint = null;
+    _startTimer();
+  }
+
+  void _drawCard() {
+    _gameService.drawCard();
+    setState(() {});
   }
 
   void _dropOnFoundation(PlayingCard card, int foundationIndex) {
-    setState(() {
-      // Try moving from waste to foundation
-      var newGameState = _gameState.moveWasteToFoundation(foundationIndex);
-      if (newGameState != null) {
-        _gameState = newGameState;
+    // Try moving from waste to foundation
+    var result = _gameService.moveWasteToFoundation(foundationIndex);
+    if (result != null) {
+      _gameService = result;
+      _checkWin();
+      setState(() {});
+      return;
+    }
+
+    // Try moving from tableau to foundation
+    for (var tableauIndex = 0; tableauIndex < 7; tableauIndex++) {
+      result = _gameService.moveTableauToFoundation(tableauIndex, foundationIndex);
+      if (result != null) {
+        _gameService = result;
+        _checkWin();
+        setState(() {});
         return;
       }
-
-      // Try moving from tableau to foundation
-      for (var tableauIndex = 0; tableauIndex < 7; tableauIndex++) {
-        newGameState = _gameState.moveTableauToFoundation(tableauIndex, foundationIndex);
-        if (newGameState != null) {
-          _gameState = newGameState;
-          return;
-        }
-      }
-    });
+    }
   }
 
   void _dropOnTableau(PlayingCard card, int tableauIndex) {
-    setState(() {
-      // Try moving from waste to tableau
-      var newGameState = _gameState.moveWasteToTableau(tableauIndex);
-      if (newGameState != null) {
-        _gameState = newGameState;
+    // Try moving from waste to tableau
+    var result = _gameService.moveWasteToTableau(tableauIndex);
+    if (result != null) {
+      _gameService = result;
+      _checkWin();
+      setState(() {});
+      return;
+    }
+
+    // Try moving from foundation to tableau
+    for (var foundationIndex = 0; foundationIndex < 4; foundationIndex++) {
+      result = _gameService.moveFoundationToTableau(foundationIndex, tableauIndex);
+      if (result != null) {
+        _gameService = result;
+        _checkWin();
+        setState(() {});
         return;
       }
+    }
 
-      // Try moving from foundation to tableau
-      for (var foundationIndex = 0; foundationIndex < 4; foundationIndex++) {
-        newGameState = _gameState.moveFoundationToTableau(foundationIndex, tableauIndex);
-        if (newGameState != null) {
-          _gameState = newGameState;
-          return;
-        }
+    // Try moving from one tableau to another
+    for (var fromTableauIndex = 0; fromTableauIndex < 7; fromTableauIndex++) {
+      if (fromTableauIndex == tableauIndex) continue;
+      result = _gameService.moveTableauToTableau(fromTableauIndex, tableauIndex);
+      if (result != null) {
+        _gameService = result;
+        _checkWin();
+        setState(() {});
+        return;
       }
+    }
+  }
 
-      // Try moving from one tableau to another
-      for (var fromTableauIndex = 0; fromTableauIndex < 7; fromTableauIndex++) {
-        if (fromTableauIndex == tableauIndex) continue;
-        newGameState = _gameState.moveTableauToTableau(fromTableauIndex, tableauIndex);
-        if (newGameState != null) {
-          _gameState = newGameState;
-          return;
-        }
-      }
-    });
+  void _checkWin() {
+    if (_gameService.isWon) {
+      _gameService.markWon();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Congratulations! You won!')),
+      );
+    }
+  }
+
+  void _undo() {
+    if (_gameService.undoStackSize > 0) {
+      _gameService.undo();
+      setState(() {});
+    }
+  }
+
+  void _showHint() {
+    final gameState = _gameService.gameState;
+    final hints = HintService().findHints(gameState);
+    if (hints.isNotEmpty) {
+      _currentHint = hints.first;
+      setState(() {});
+      // Clear hint after 2 seconds
+      Future.delayed(const Duration(seconds: 2), () {
+        setState(() {
+          _currentHint = null;
+        });
+      });
+    }
+  }
+
+  void _openSettings() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => SettingsScreen(
+          options: _gameService.options,
+          onOptionsChanged: (newOptions) {
+            _gameService.updateOptions(newOptions);
+          },
+        ),
+      ),
+    );
   }
 
   @override
@@ -101,12 +179,44 @@ class _SolitaireHomeState extends State<SolitaireHome> {
       appBar: AppBar(
         title: const Text('Solitaire'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: _openSettings,
+          ),
+        ],
       ),
-      body: BoardWidget(
-        gameState: _gameState,
-        onStockTap: _drawFromStock,
-        onDropOnFoundation: _dropOnFoundation,
-        onDropOnTableau: _dropOnTableau,
+      body: Column(
+        children: [
+          // Score display
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ScoreDisplayWidget(
+              score: _gameService.score,
+              showTimer: _gameService.options.timedMode,
+            ),
+          ),
+          // Control buttons
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: ControlButtonsWidget(
+              onNewGame: _startNewGame,
+              onUndo: _undo,
+              onHint: _showHint,
+              undoEnabled: _gameService.undoStackSize > 0,
+            ),
+          ),
+          // Game board
+          Expanded(
+            child: BoardWidget(
+              gameState: _gameService.gameState,
+              onStockTap: _drawCard,
+              onDropOnFoundation: _dropOnFoundation,
+              onDropOnTableau: _dropOnTableau,
+              hint: _currentHint,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/domain/game_state_options.dart
+++ b/lib/src/domain/game_state_options.dart
@@ -9,17 +9,26 @@ enum ScoringMode {
   vegas,
 }
 
+enum CardBackDesign {
+  classic,
+  blue,
+  red,
+  green,
+}
+
 class GameStateOptions {
   final DrawMode drawMode;
   final ScoringMode scoringMode;
   final bool timedMode;
   final bool soundEnabled;
+  final CardBackDesign cardBackDesign;
 
   const GameStateOptions({
     this.drawMode = DrawMode.drawOne,
     this.scoringMode = ScoringMode.classic,
     this.timedMode = false,
     this.soundEnabled = true,
+    this.cardBackDesign = CardBackDesign.classic,
   });
 
   /// Creates a copy with the given fields replaced.
@@ -28,12 +37,14 @@ class GameStateOptions {
     ScoringMode? scoringMode,
     bool? timedMode,
     bool? soundEnabled,
+    CardBackDesign? cardBackDesign,
   }) {
     return GameStateOptions(
       drawMode: drawMode ?? this.drawMode,
       scoringMode: scoringMode ?? this.scoringMode,
       timedMode: timedMode ?? this.timedMode,
       soundEnabled: soundEnabled ?? this.soundEnabled,
+      cardBackDesign: cardBackDesign ?? this.cardBackDesign,
     );
   }
 
@@ -44,7 +55,8 @@ class GameStateOptions {
         other.drawMode == drawMode &&
         other.scoringMode == scoringMode &&
         other.timedMode == timedMode &&
-        other.soundEnabled == soundEnabled;
+        other.soundEnabled == soundEnabled &&
+        other.cardBackDesign == cardBackDesign;
   }
 
   @override
@@ -52,5 +64,6 @@ class GameStateOptions {
       drawMode.hashCode ^
       scoringMode.hashCode ^
       timedMode.hashCode ^
-      soundEnabled.hashCode;
+      soundEnabled.hashCode ^
+      cardBackDesign.hashCode;
 }

--- a/lib/src/screens/settings_screen.dart
+++ b/lib/src/screens/settings_screen.dart
@@ -1,0 +1,295 @@
+import 'package:flutter/material.dart';
+import 'package:solitaire/src/domain/game_state_options.dart';
+
+/// A screen that displays and allows modification of game settings.
+class SettingsScreen extends StatefulWidget {
+  /// The current game options.
+  final GameStateOptions options;
+
+  /// Callback when the options are changed.
+  final Function(GameStateOptions newOptions) onOptionsChanged;
+
+  const SettingsScreen({
+    super.key,
+    required this.options,
+    required this.onOptionsChanged,
+  });
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  late GameStateOptions _localOptions;
+
+  @override
+  void initState() {
+    super.initState();
+    _localOptions = widget.options;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: ListView(
+        children: [
+          _SettingsSection(
+            title: 'Game Settings',
+            children: [
+              _DrawModeSection(
+                currentMode: _localOptions.drawMode,
+                onChanged: (mode) {
+                  setState(() {
+                    _localOptions = _localOptions.copyWith(drawMode: mode);
+                  });
+                  widget.onOptionsChanged(_localOptions);
+                },
+              ),
+              const Divider(height: 1),
+              _ScoringModeSection(
+                currentMode: _localOptions.scoringMode,
+                onChanged: (mode) {
+                  setState(() {
+                    _localOptions = _localOptions.copyWith(scoringMode: mode);
+                  });
+                  widget.onOptionsChanged(_localOptions);
+                },
+              ),
+              const Divider(height: 1),
+              _TimedModeSection(
+                isEnabled: _localOptions.timedMode,
+                onChanged: (enabled) {
+                  setState(() {
+                    _localOptions = _localOptions.copyWith(timedMode: enabled);
+                  });
+                  widget.onOptionsChanged(_localOptions);
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _SettingsSection(
+            title: 'Appearance',
+            children: [
+              _CardBackSection(
+                currentDesign: _localOptions.cardBackDesign,
+                onChanged: (design) {
+                  setState(() {
+                    _localOptions = _localOptions.copyWith(cardBackDesign: design);
+                  });
+                  widget.onOptionsChanged(_localOptions);
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: _InfoCard(
+              title: 'Scoring Info',
+              content: _localOptions.scoringMode == ScoringMode.vegas
+                  ? 'Vegas Mode: +10 points for waste→tableau and tableau→foundation moves. -2 points per 10 seconds in timed mode. -100 points for undo.'
+                  : 'Classic Mode: No scoring. Just enjoy the game!',
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsSection extends StatelessWidget {
+  final String title;
+  final List<Widget> children;
+
+  const _SettingsSection({
+    required this.title,
+    required this.children,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            title,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+          ),
+        ),
+        Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+            border: Border.all(color: Theme.of(context).dividerColor),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(children: children),
+        ),
+      ],
+    );
+  }
+}
+
+class _DrawModeSection extends StatelessWidget {
+  final DrawMode currentMode;
+  final Function(DrawMode?) onChanged;
+
+  const _DrawModeSection({
+    required this.currentMode,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return RadioListTile<DrawMode>(
+      title: const Text('Draw One'),
+      subtitle: const Text('Draw one card at a time'),
+      value: DrawMode.drawOne,
+      groupValue: currentMode,
+      onChanged: onChanged,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+    );
+  }
+}
+
+class _ScoringModeSection extends StatelessWidget {
+  final ScoringMode currentMode;
+  final Function(ScoringMode?) onChanged;
+
+  const _ScoringModeSection({
+    required this.currentMode,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        RadioListTile<ScoringMode>(
+          title: const Text('Classic'),
+          subtitle: const Text('No scoring, just play'),
+          value: ScoringMode.classic,
+          groupValue: currentMode,
+          onChanged: onChanged,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
+        RadioListTile<ScoringMode>(
+          title: const Text('Vegas'),
+          subtitle: const Text('Points for moves, penalties for time'),
+          value: ScoringMode.vegas,
+          groupValue: currentMode,
+          onChanged: onChanged,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
+      ],
+    );
+  }
+}
+
+class _TimedModeSection extends StatelessWidget {
+  final bool isEnabled;
+  final Function(bool) onChanged;
+
+  const _TimedModeSection({
+    required this.isEnabled,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      title: const Text('Timed Mode'),
+      subtitle: const Text('Enable time-based scoring'),
+      value: isEnabled,
+      onChanged: onChanged,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+    );
+  }
+}
+
+class _CardBackSection extends StatelessWidget {
+  final CardBackDesign currentDesign;
+  final Function(CardBackDesign?) onChanged;
+
+  const _CardBackSection({
+    required this.currentDesign,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        RadioListTile<CardBackDesign>(
+          title: const Text('Classic Blue'),
+          value: CardBackDesign.classic,
+          groupValue: currentDesign,
+          onChanged: onChanged,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
+        RadioListTile<CardBackDesign>(
+          title: const Text('Blue'),
+          value: CardBackDesign.blue,
+          groupValue: currentDesign,
+          onChanged: onChanged,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
+        RadioListTile<CardBackDesign>(
+          title: const Text('Red'),
+          value: CardBackDesign.red,
+          groupValue: currentDesign,
+          onChanged: onChanged,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
+        RadioListTile<CardBackDesign>(
+          title: const Text('Green'),
+          value: CardBackDesign.green,
+          groupValue: currentDesign,
+          onChanged: onChanged,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
+      ],
+    );
+  }
+}
+
+class _InfoCard extends StatelessWidget {
+  final String title;
+  final String content;
+
+  const _InfoCard({
+    required this.title,
+    required this.content,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(content),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/screens/settings_screen.dart
+++ b/lib/src/screens/settings_screen.dart
@@ -141,7 +141,7 @@ class _SettingsSection extends StatelessWidget {
 
 class _DrawModeSection extends StatelessWidget {
   final DrawMode currentMode;
-  final Function(DrawMode?) onChanged;
+  final Function(DrawMode) onChanged;
 
   const _DrawModeSection({
     required this.currentMode,
@@ -150,20 +150,28 @@ class _DrawModeSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RadioListTile<DrawMode>(
-      title: const Text('Draw One'),
-      subtitle: const Text('Draw one card at a time'),
-      value: DrawMode.drawOne,
-      groupValue: currentMode,
-      onChanged: onChanged,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+    return Column(
+      children: [
+        _RadioOption(
+          title: const Text('Draw One'),
+          subtitle: const Text('Draw one card at a time'),
+          isSelected: currentMode == DrawMode.drawOne,
+          onTap: () => onChanged(DrawMode.drawOne),
+        ),
+        _RadioOption(
+          title: const Text('Draw Three'),
+          subtitle: const Text('Draw three cards at a time'),
+          isSelected: currentMode == DrawMode.drawThree,
+          onTap: () => onChanged(DrawMode.drawThree),
+        ),
+      ],
     );
   }
 }
 
 class _ScoringModeSection extends StatelessWidget {
   final ScoringMode currentMode;
-  final Function(ScoringMode?) onChanged;
+  final Function(ScoringMode) onChanged;
 
   const _ScoringModeSection({
     required this.currentMode,
@@ -174,21 +182,17 @@ class _ScoringModeSection extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        RadioListTile<ScoringMode>(
+        _RadioOption(
           title: const Text('Classic'),
           subtitle: const Text('No scoring, just play'),
-          value: ScoringMode.classic,
-          groupValue: currentMode,
-          onChanged: onChanged,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          isSelected: currentMode == ScoringMode.classic,
+          onTap: () => onChanged(ScoringMode.classic),
         ),
-        RadioListTile<ScoringMode>(
+        _RadioOption(
           title: const Text('Vegas'),
           subtitle: const Text('Points for moves, penalties for time'),
-          value: ScoringMode.vegas,
-          groupValue: currentMode,
-          onChanged: onChanged,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          isSelected: currentMode == ScoringMode.vegas,
+          onTap: () => onChanged(ScoringMode.vegas),
         ),
       ],
     );
@@ -218,7 +222,7 @@ class _TimedModeSection extends StatelessWidget {
 
 class _CardBackSection extends StatelessWidget {
   final CardBackDesign currentDesign;
-  final Function(CardBackDesign?) onChanged;
+  final Function(CardBackDesign) onChanged;
 
   const _CardBackSection({
     required this.currentDesign,
@@ -229,35 +233,71 @@ class _CardBackSection extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        RadioListTile<CardBackDesign>(
+        _RadioOption(
           title: const Text('Classic Blue'),
-          value: CardBackDesign.classic,
-          groupValue: currentDesign,
-          onChanged: onChanged,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          isSelected: currentDesign == CardBackDesign.classic,
+          onTap: () => onChanged(CardBackDesign.classic),
         ),
-        RadioListTile<CardBackDesign>(
+        _RadioOption(
           title: const Text('Blue'),
-          value: CardBackDesign.blue,
-          groupValue: currentDesign,
-          onChanged: onChanged,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          isSelected: currentDesign == CardBackDesign.blue,
+          onTap: () => onChanged(CardBackDesign.blue),
         ),
-        RadioListTile<CardBackDesign>(
+        _RadioOption(
           title: const Text('Red'),
-          value: CardBackDesign.red,
-          groupValue: currentDesign,
-          onChanged: onChanged,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          isSelected: currentDesign == CardBackDesign.red,
+          onTap: () => onChanged(CardBackDesign.red),
         ),
-        RadioListTile<CardBackDesign>(
+        _RadioOption(
           title: const Text('Green'),
-          value: CardBackDesign.green,
-          groupValue: currentDesign,
-          onChanged: onChanged,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          isSelected: currentDesign == CardBackDesign.green,
+          onTap: () => onChanged(CardBackDesign.green),
         ),
       ],
+    );
+  }
+}
+
+class _RadioOption extends StatelessWidget {
+  final Widget title;
+  final Widget? subtitle;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _RadioOption({
+    required this.title,
+    this.subtitle,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  title,
+                  if (subtitle != null) ...[
+                    const SizedBox(height: 4),
+                    subtitle!,
+                  ],
+                ],
+              ),
+            ),
+            Icon(
+              isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+              color: isSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/src/widgets/board_widget.dart
+++ b/lib/src/widgets/board_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:solitaire/src/domain/game_state.dart';
 import 'package:solitaire/src/domain/playing_card.dart';
+import 'package:solitaire/src/hint_service.dart';
 import 'package:solitaire/src/widgets/foundation_pile_widget.dart';
 import 'package:solitaire/src/widgets/stock_pile_widget.dart';
 import 'package:solitaire/src/widgets/tableau_pile_widget.dart';
@@ -24,13 +25,33 @@ class BoardWidget extends StatelessWidget {
   /// Callback when a card is dropped on a tableau.
   final Function(PlayingCard card, int tableauIndex) onDropOnTableau;
 
+  /// The current hint to highlight, if any.
+  final Hint? hint;
+
   const BoardWidget({
     super.key,
     required this.gameState,
     required this.onStockTap,
     required this.onDropOnFoundation,
     required this.onDropOnTableau,
+    this.hint,
   });
+
+  bool _isHinted(int tableauIndex) {
+    if (hint == null) return false;
+    return hint!.tableauIndex == tableauIndex || hint!.targetTableauIndex == tableauIndex;
+  }
+
+  bool _isHintedFoundation(int foundationIndex) {
+    if (hint == null) return false;
+    return hint!.foundationsIndex == foundationIndex;
+  }
+
+  bool _isHintedWaste() {
+    if (hint == null) return false;
+    return hint!.type == HintType.wasteToFoundation ||
+           hint!.type == HintType.wasteToTableau;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -65,7 +86,7 @@ class BoardWidget extends StatelessWidget {
           // Stock pile
           StockPileWidget(pile: gameState.stockPile, onTap: onStockTap),
           // Waste pile
-          WastePileWidget(pile: gameState.wastePile),
+          WastePileWidget(pile: gameState.wastePile, isHinted: _isHintedWaste()),
           // Gap
           const SizedBox(width: 60),
           // Foundation piles (up to 4)
@@ -74,6 +95,7 @@ class BoardWidget extends StatelessWidget {
               pile: foundationPiles[i],
               foundationIndex: i,
               onDrop: onDropOnFoundation,
+              isHinted: _isHintedFoundation(i),
             ),
         ],
       ),
@@ -96,6 +118,7 @@ class BoardWidget extends StatelessWidget {
                     xOffset: 0,
                     tableauIndex: index,
                     onDrop: onDropOnTableau,
+                    isHinted: _isHinted(index),
                   )
                 : const SizedBox.shrink(),
           ),

--- a/lib/src/widgets/control_buttons_widget.dart
+++ b/lib/src/widgets/control_buttons_widget.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// A widget that displays control buttons for the game.
+class ControlButtonsWidget extends StatelessWidget {
+  /// Callback when the New Game button is tapped.
+  final VoidCallback onNewGame;
+
+  /// Callback when the Undo button is tapped.
+  final VoidCallback onUndo;
+
+  /// Callback when the Hint button is tapped.
+  final VoidCallback onHint;
+
+  /// Whether the undo button should be enabled.
+  final bool undoEnabled;
+
+  const ControlButtonsWidget({
+    super.key,
+    required this.onNewGame,
+    required this.onUndo,
+    required this.onHint,
+    this.undoEnabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _ControlButton(
+          icon: Icons.refresh,
+          label: 'New Game',
+          onTap: onNewGame,
+        ),
+        const SizedBox(width: 12),
+        _ControlButton(
+          icon: Icons.undo,
+          label: 'Undo',
+          onTap: onUndo,
+          enabled: undoEnabled,
+        ),
+        const SizedBox(width: 12),
+        _ControlButton(
+          icon: Icons.lightbulb,
+          label: 'Hint',
+          onTap: onHint,
+        ),
+      ],
+    );
+  }
+}
+
+class _ControlButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final bool enabled;
+
+  const _ControlButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.enabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: enabled ? onTap : null,
+      style: TextButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: 6),
+          Text(label),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/foundation_pile_widget.dart
+++ b/lib/src/widgets/foundation_pile_widget.dart
@@ -16,11 +16,15 @@ class FoundationPileWidget extends StatelessWidget {
   /// The index of this foundation pile (0-3).
   final int foundationIndex;
 
+  /// Whether this pile is highlighted as part of a hint.
+  final bool isHinted;
+
   const FoundationPileWidget({
     super.key,
     required this.pile,
     this.onDrop,
     this.foundationIndex = 0,
+    this.isHinted = false,
   });
 
   @override
@@ -40,17 +44,20 @@ class FoundationPileWidget extends StatelessWidget {
       },
       builder: (context, candidateData, rejectedData) {
         final isDragOver = candidateData.isNotEmpty;
+        final borderColor = isHinted ? Colors.green : (isDragOver ? Colors.green : Colors.grey);
+        final borderWidth = isHinted ? 3.0 : (isDragOver ? 3.0 : 2.0);
+        final bgColor = isHinted ? Colors.green.withValues(alpha: 0.2) : (isDragOver ? Colors.green.withValues(alpha: 0.2) : null);
         return Container(
           width: 80,
           height: 120,
           margin: const EdgeInsets.all(4),
           decoration: BoxDecoration(
             border: Border.all(
-              color: isDragOver ? Colors.green : Colors.grey,
-              width: isDragOver ? 3 : 2,
+              color: borderColor,
+              width: borderWidth,
             ),
             borderRadius: BorderRadius.circular(8),
-            color: isDragOver ? Colors.green.withValues(alpha: 0.2) : null,
+            color: bgColor,
           ),
           child: Center(
             child: pile.isEmpty
@@ -58,7 +65,7 @@ class FoundationPileWidget extends StatelessWidget {
                     'A',
                     style: TextStyle(
                       fontSize: 48,
-                      color: Colors.grey,
+                      color: isHinted ? Colors.green : Colors.grey,
                       fontWeight: FontWeight.bold,
                     ),
                   )

--- a/lib/src/widgets/score_display_widget.dart
+++ b/lib/src/widgets/score_display_widget.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:solitaire/src/domain/game_score.dart';
+
+/// A widget that displays the current game score, moves, and elapsed time.
+class ScoreDisplayWidget extends StatelessWidget {
+  /// The current game score.
+  final GameScore score;
+
+  /// Whether to show the timer (only shown in timed mode).
+  final bool showTimer;
+
+  const ScoreDisplayWidget({
+    super.key,
+    required this.score,
+    this.showTimer = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _ScoreItem(
+            label: 'Score',
+            value: score.score.toString(),
+          ),
+          const SizedBox(width: 16),
+          _ScoreItem(
+            label: 'Moves',
+            value: score.moves.toString(),
+          ),
+          if (showTimer) ...[
+            const SizedBox(width: 16),
+            _ScoreItem(
+              label: 'Time',
+              value: _formatDuration(score.elapsedDuration),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _formatDuration(Duration duration) {
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
+  }
+}
+
+class _ScoreItem extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _ScoreItem({
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/widgets/tableau_pile_widget.dart
+++ b/lib/src/widgets/tableau_pile_widget.dart
@@ -22,6 +22,9 @@ class TableauPileWidget extends StatelessWidget {
   /// The index of this tableau pile (0-6).
   final int tableauIndex;
 
+  /// Whether this pile is highlighted as part of a hint.
+  final bool isHinted;
+
   const TableauPileWidget({
     super.key,
     required this.pile,
@@ -29,6 +32,7 @@ class TableauPileWidget extends StatelessWidget {
     this.onDrop,
     this.onAutoMove,
     this.tableauIndex = 0,
+    this.isHinted = false,
   });
 
   @override
@@ -85,10 +89,12 @@ class TableauPileWidget extends StatelessWidget {
       final stack = _getFaceUpStack();
 
       // Build the card widget with optional drag
+      final isHighlighted = isHinted || isDragOver;
       final cardWidget = Container(
         decoration: BoxDecoration(
-          border: isDragOver ? Border.all(color: Colors.green, width: 2) : null,
+          border: isHighlighted ? Border.all(color: Colors.green, width: 2) : null,
           borderRadius: BorderRadius.circular(8),
+          color: isHighlighted ? Colors.green.withValues(alpha: 0.2) : null,
         ),
         child: CardWidget(card: card),
       );
@@ -116,6 +122,7 @@ class TableauPileWidget extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(8),
+          color: isHinted ? Colors.green.withValues(alpha: 0.2) : null,
         ),
         child: CardWidget(card: card),
       ),

--- a/lib/src/widgets/waste_pile_widget.dart
+++ b/lib/src/widgets/waste_pile_widget.dart
@@ -16,11 +16,15 @@ class WastePileWidget extends StatelessWidget {
   /// Callback when a card is dropped on a target.
   final Function(PlayingCard card)? onDrop;
 
+  /// Whether this pile is highlighted as part of a hint.
+  final bool isHinted;
+
   const WastePileWidget({
     super.key,
     required this.pile,
     this.onTap,
     this.onDrop,
+    this.isHinted = false,
   });
 
   @override
@@ -33,8 +37,9 @@ class WastePileWidget extends StatelessWidget {
           height: 120,
           margin: const EdgeInsets.all(4),
           decoration: BoxDecoration(
-            border: Border.all(color: Colors.grey, width: 2),
+            border: Border.all(color: isHinted ? Colors.green : Colors.grey, width: isHinted ? 3 : 2),
             borderRadius: BorderRadius.circular(8),
+            color: isHinted ? Colors.green.withValues(alpha: 0.2) : null,
           ),
           child: const SizedBox.shrink(),
         ),
@@ -53,8 +58,9 @@ class WastePileWidget extends StatelessWidget {
             height: 120,
             margin: const EdgeInsets.all(4),
             decoration: BoxDecoration(
-              border: Border.all(color: Colors.grey, width: 2),
+              border: Border.all(color: isHinted ? Colors.green : Colors.grey, width: isHinted ? 3 : 2),
               borderRadius: BorderRadius.circular(8),
+              color: isHinted ? Colors.green.withValues(alpha: 0.2) : null,
             ),
             child: Draggable<List<PlayingCard>>(
               data: [topCard],


### PR DESCRIPTION
Closes #22

## Summary

Implemented the UI layer for Phase 7 - Scoring & Game Options. The data layer (GameService, GameScore, GameStateOptions, HintService) was already complete from previous phases.

## Changes

### New Widgets
- `ScoreDisplayWidget` - Displays score, moves, and elapsed time (MM:SS format)
- `ControlButtonsWidget` - New Game, Undo (disabled when empty), Hint buttons
- `SettingsScreen` - Full-screen settings with game options

### Updates
- `main.dart` - Switched from GameState to GameService, added Timer for live updates
- `board_widget.dart` and pile widgets - Added hint highlighting support
- `game_state_options.dart` - Added CardBackDesign enum

## Test Results

All 259 tests passing with 90%+ coverage.

## Verification

- [x] New Game button resets game and score to 0
- [x] Score display updates on moves
- [x] Timer counts up in timed mode
- [x] Undo reverts state and adjusts score (Vegas: -100)
- [x] Hint highlights valid moves
- [x] Settings changes persist during gameplay